### PR TITLE
Allowing use of `Week` and `Month` frequencies

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  TF_VERSION: 1.0.4
+  TF_VERSION: 1.3.1
 
 jobs:
   terraform:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,46 @@ module "vm_automation" {
 
 ```
 
+Below is an example of a mon-friday schedule
+
+```terraform
+# =================================================================
+# ==========    vm shutdown/start runbook module    ===============
+# =================================================================
+#  vm shutdown/start runbook module
+module "vm_automation" {
+  source = "git::https://github.com/hmcts/cnp-module-automation-runbook-start-stop-vm"
+
+  product                 = "xyz"
+  env                     = "sbox"
+  location                = "uksouth"
+  automation_account_name = "xyz-sbox-aa"
+  schedules       = [
+                      {
+                        name        = "vm-on"
+                        frequency   = "Week"
+                        interval    = 1
+                        run_time    = "06:00:00"
+                        start_vm    = true
+                        week_days   = ['Monday','Tuesday','Wednesday','Thursday','Friday']
+                      },
+                      {
+                        name        = "vm-off"
+                        frequency   = "Week"
+                        interval    = 1
+                        run_time    = formatdate("HH:mm:ss", timestamp())
+                        start_vm    = false
+                        week_days   = ['Monday','Tuesday','Wednesday','Thursday','Friday']
+                      }
+                     ]
+  resource_group_name     = "xyz-sbox-rg"
+  vm_names                = ["xyz-sbox-vm1", "xyz-sbox-vm2"]
+  tags                    = var.common_tags
+}
+
+
+```
+
 ## Requirements   
 
 | Name | Version |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ module "vm_automation" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 
 ## Providers
 
@@ -117,10 +117,29 @@ No modules.
 | location | Location | `string` | uksouth | no |  
 | automation_account_name | Automation account name | `string` | n/a | yes |   
 | resource_group_name | Resource group name | `string` | n/a | yes |  
-| schedules | Object containaing schedules name, frequency, interval, start time and desired state | `object` | n/a | yes |  
+| schedules | Object containaing schedules name, frequency, interval, start time and desired state | `schedules object` | n/a | yes |  
 | vm_names | Names of VMs to apply runbook to | `array` | [] | no |  
 | timezone | timezone | `string` | Europe/London | no |  
 | tags | Runbook Tags | `map(string)` | n/a | yes |
+
+### Schedules object
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name | Specifies the name of the Schedule | `string` | n/a | yes |
+| frequency | The frequency of the schedule. - can be either `OneTime`, `Day`, `Hour`, `Week`, or `Month`. | `string` | n/a | yes |
+| interval | The number of frequencys between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1` | `string` | n/a | yes |
+| run_time | Time the schedule should run | `string` | n/a | yes |
+| start_vm | What action to be taken `true` to start VM, `false` to shutdown VM | `bool` | n/a | yes |
+| week_days | List of days of the week that the job should execute on. Only valid when frequency is `Week` | `list` | n/a | no |
+| month_days | List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month` | `list` | n/a | yes |
+| monthly_occurrence | List of occurrences of days within a month | `monthly_occurrence object` | n/a | yes |
+
+### monthly_occurrence object
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| day | Day of the occurrence. Must be one of `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday` | `string` | n/a | yes |
+| occurrence | Occurrence of the week within the month. Must be between `1` and `5`. `-1` for last week within the month | `number` | n/a | yes |
+
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ No modules.
 | run_time | Time the schedule should run | `string` | n/a | yes |
 | start_vm | What action to be taken `true` to start VM, `false` to shutdown VM | `bool` | n/a | yes |
 | week_days | List of days of the week that the job should execute on. Only valid when frequency is `Week` | `list` | n/a | no |
-| month_days | List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month` | `list` | n/a | yes |
-| monthly_occurrence | List of occurrences of days within a month | `monthly_occurrence object` | n/a | yes |
+| month_days | List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month` | `list` | n/a | no |
+| monthly_occurrence | List of occurrences of days within a month | `monthly_occurrence object` | n/a | no |
 
 ### monthly_occurrence object
 | Name | Description | Type | Default | Required |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ module "vm_automation" {
                         interval    = 1
                         run_time    = "06:00:00"
                         start_vm    = true
-                        week_days   = ['Monday','Tuesday','Wednesday','Thursday','Friday']
+                        week_days   = ["Monday","Tuesday","Wednesday","Thursday","Friday"]
                       },
                       {
                         name        = "vm-off"
@@ -73,7 +73,7 @@ module "vm_automation" {
                         interval    = 1
                         run_time    = formatdate("HH:mm:ss", timestamp())
                         start_vm    = false
-                        week_days   = ['Monday','Tuesday','Wednesday','Thursday','Friday']
+                        week_days   = ["Monday","Tuesday","Wednesday","Thursday","Friday"]
                       }
                      ]
   resource_group_name     = "xyz-sbox-rg"

--- a/runbook.tf
+++ b/runbook.tf
@@ -23,7 +23,19 @@ resource "azurerm_automation_schedule" "vm-start-stop" {
   frequency               = each.value.frequency
   week_days               = each.value.frequency == "Week" ? each.value.week_days : null
   month_days              = each.value.frequency == "Month" ? each.value.month_days : null
-  monthly_occurrence      = each.value.frequency == "Month" ? each.value.monthly_occurrence : null
+  dynamic monthly_occurrence {
+    for_each = each.value.frequency == "Month" && each.value.month_days == null ? [1] : []
+    
+    # [
+    #   for mo in each.value : mo.monthly_occurrence
+    #   if each.value.frequency == "Month" && each.value.month_days == null
+    # ]
+    content {
+      day        = each.value.monthly_occurrence.day
+      occurrence = each.value.monthly_occurrence.occurrence
+    }
+  }
+
   interval                = each.value.interval
   timezone                = var.timezone
   start_time              = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T${each.value.run_time}Z"

--- a/runbook.tf
+++ b/runbook.tf
@@ -22,6 +22,8 @@ resource "azurerm_automation_schedule" "vm-start-stop" {
   automation_account_name = var.automation_account_name
   frequency               = each.value.frequency
   week_days               = each.value.frequency == "Week" ? each.value.week_days : null
+  month_days              = each.value.frequency == "Month" ? each.value.month_days : null
+  monthly_occurrence      = each.value.frequency == "Month" ? each.value.monthly_occurrence : null
   interval                = each.value.interval
   timezone                = var.timezone
   start_time              = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T${each.value.run_time}Z"

--- a/runbook.tf
+++ b/runbook.tf
@@ -21,7 +21,7 @@ resource "azurerm_automation_schedule" "vm-start-stop" {
   resource_group_name     = var.resource_group_name
   automation_account_name = var.automation_account_name
   frequency               = each.value.frequency
-  week_days               = each.value.frequency == "Week" ? each.week_days : null
+  week_days               = each.value.frequency == "Week" ? each.value.week_days : null
   interval                = each.value.interval
   timezone                = var.timezone
   start_time              = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T${each.value.run_time}Z"

--- a/runbook.tf
+++ b/runbook.tf
@@ -23,9 +23,9 @@ resource "azurerm_automation_schedule" "vm-start-stop" {
   frequency               = each.value.frequency
   week_days               = each.value.frequency == "Week" ? each.value.week_days : null
   month_days              = each.value.frequency == "Month" ? each.value.month_days : null
-  dynamic monthly_occurrence {
+  dynamic "monthly_occurrence" {
     for_each = each.value.frequency == "Month" && each.value.month_days == null ? [1] : []
-    
+
     # [
     #   for mo in each.value : mo.monthly_occurrence
     #   if each.value.frequency == "Month" && each.value.month_days == null
@@ -36,10 +36,10 @@ resource "azurerm_automation_schedule" "vm-start-stop" {
     }
   }
 
-  interval                = each.value.interval
-  timezone                = var.timezone
-  start_time              = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T${each.value.run_time}Z"
-  description             = "Schedule to ${each.value.start_vm == true ? "start" : "stop"} vm at ${each.value.run_time}"
+  interval    = each.value.interval
+  timezone    = var.timezone
+  start_time  = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T${each.value.run_time}Z"
+  description = "Schedule to ${each.value.start_vm == true ? "start" : "stop"} vm at ${each.value.run_time}"
 
   depends_on = [
     azurerm_automation_runbook.vm-start-stop

--- a/runbook.tf
+++ b/runbook.tf
@@ -21,6 +21,7 @@ resource "azurerm_automation_schedule" "vm-start-stop" {
   resource_group_name     = var.resource_group_name
   automation_account_name = var.automation_account_name
   frequency               = each.value.frequency
+  week_days               = each.value.frequency == "Week" ? each.week_days : null
   interval                = each.value.interval
   timezone                = var.timezone
   start_time              = "${formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))}T${each.value.run_time}Z"

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,72 @@ variable "schedules" {
     week_days          = optional(list(string))
     month_days         = optional(list(number))
     monthly_occurrence = optional(object({
-      day        = string
-      occurrence = number
+      day        = optional(string)
+      occurrence = optional(number)
     }))
   }))
   default = []
+
+  validation { # Check no interval for OneTime
+    condition = alltrue(flatten([
+      for s in var.schedules : can(s.interval) == false
+      if s.frequency == "OneTime" 
+    ]))
+    error_message = "Cannot provide an interval when using 'oneTime'"
+  }
+
+  validation { # Check for valid frequency
+    condition = alltrue([
+      for s in var.schedules : contains(["OneTime", "Day", "Hour", "Week", "Month"], s.frequency)
+    ])
+    error_message = "'frequency' must be one of the following: 'OneTime', 'Day', 'Hour', 'Week', or 'Month'."
+  }
+
+  validation { #Check for valid time format
+    condition = alltrue([
+      for s in var.schedules : can(regex("^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$", s.run_time))
+    ])
+    error_message = "'run_time' must be be in the format 'HH:MM:SS'."
+  }
+  
+  validation { # Check valid week days
+    condition = alltrue(flatten([
+      for s in var.schedules : [
+        for d in s.week_days : contains(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"], d)
+      ]
+      if s.frequency == "Week" && s.week_days != null
+    ]))
+    error_message = "Must provide a valid 'week_days' option when using a frequency of 'Week', valid options are: 'Monday', 'Tuesday', 'Wednesday', 'Thursday' or 'Friday'."
+  }
+
+  validation { # Check month numbers are in range
+    condition = alltrue(flatten([
+      for s in var.schedules : [
+          for d in s.month_days : (d >= -1 && d <=31)
+        ]
+      if s.frequency == "Month" && s.month_days != null
+    ]))
+    error_message = "You must provide a valid 'month_days' option when using a frequency of 'Month', valid options are: 1 - 31 or -1 (for last day of the month)."
+  }
+
+  validation { # Check for valid monthly_occurrence.day
+    condition = alltrue([
+      for s in var.schedules : 
+        contains(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"], s.monthly_occurrence.day)
+        if s.frequency == "Month" && s.monthly_occurrence != null
+    ])
+    error_message = "'monthly_occurrence.day' must be one of the following: 'Monday', 'Tuesday', 'Wednesday', 'Thursday' or 'Friday'"
+  }
+
+  validation { # Check for valid monthly_occurrence.occurrence
+    condition = alltrue([
+      for s in var.schedules : 
+        s.monthly_occurrence.occurrence >= -1 && s.monthly_occurrence.occurrence <= 5
+        if s.frequency == "Month" && s.monthly_occurrence != null
+    ])
+    error_message = "Occurrence of the week within the month must be between 1 and 5 or -1 for last week within the month."
+  }
+
 }
 variable "resource_group_name" {
   type = string

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "schedules" {
     interval  = number
     run_time  = string
     start_vm  = bool
-    week_days = optional(list(string))
+    week_days = optional(list(string), null)
   }))
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,12 +16,17 @@ variable "tags" {
 ## Azure Automation
 variable "schedules" {
   type = list(object({
-    name      = string
-    frequency = string
-    interval  = number
-    run_time  = string
-    start_vm  = bool
-    week_days = optional(list(string), null)
+    name               = string
+    frequency          = string
+    interval           = number
+    run_time           = string
+    start_vm           = bool
+    week_days          = optional(list(string))
+    month_days         = optional(list(number))
+    monthly_occurrence = optional(object({
+      day        = string
+      occurrence = number
+    }))
   }))
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,13 +16,13 @@ variable "tags" {
 ## Azure Automation
 variable "schedules" {
   type = list(object({
-    name               = string
-    frequency          = string
-    interval           = number
-    run_time           = string
-    start_vm           = bool
-    week_days          = optional(list(string))
-    month_days         = optional(list(number))
+    name       = string
+    frequency  = string
+    interval   = number
+    run_time   = string
+    start_vm   = bool
+    week_days  = optional(list(string))
+    month_days = optional(list(number))
     monthly_occurrence = optional(object({
       day        = optional(string)
       occurrence = optional(number)
@@ -33,7 +33,7 @@ variable "schedules" {
   validation { # Check no interval for OneTime
     condition = alltrue(flatten([
       for s in var.schedules : can(s.interval) == false
-      if s.frequency == "OneTime" 
+      if s.frequency == "OneTime"
     ]))
     error_message = "Cannot provide an interval when using 'oneTime'"
   }
@@ -51,7 +51,7 @@ variable "schedules" {
     ])
     error_message = "'run_time' must be be in the format 'HH:MM:SS'."
   }
-  
+
   validation { # Check valid week days
     condition = alltrue(flatten([
       for s in var.schedules : [
@@ -65,8 +65,8 @@ variable "schedules" {
   validation { # Check month numbers are in range
     condition = alltrue(flatten([
       for s in var.schedules : [
-          for d in s.month_days : (d >= -1 && d <=31)
-        ]
+        for d in s.month_days : (d >= -1 && d <= 31)
+      ]
       if s.frequency == "Month" && s.month_days != null
     ]))
     error_message = "You must provide a valid 'month_days' option when using a frequency of 'Month', valid options are: 1 - 31 or -1 (for last day of the month)."
@@ -74,18 +74,18 @@ variable "schedules" {
 
   validation { # Check for valid monthly_occurrence.day
     condition = alltrue([
-      for s in var.schedules : 
-        contains(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"], s.monthly_occurrence.day)
-        if s.frequency == "Month" && s.monthly_occurrence != null
+      for s in var.schedules :
+      contains(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"], s.monthly_occurrence.day)
+      if s.frequency == "Month" && s.monthly_occurrence != null
     ])
     error_message = "'monthly_occurrence.day' must be one of the following: 'Monday', 'Tuesday', 'Wednesday', 'Thursday' or 'Friday'"
   }
 
   validation { # Check for valid monthly_occurrence.occurrence
     condition = alltrue([
-      for s in var.schedules : 
-        s.monthly_occurrence.occurrence >= -1 && s.monthly_occurrence.occurrence <= 5
-        if s.frequency == "Month" && s.monthly_occurrence != null
+      for s in var.schedules :
+      s.monthly_occurrence.occurrence >= -1 && s.monthly_occurrence.occurrence <= 5
+      if s.frequency == "Month" && s.monthly_occurrence != null
     ])
     error_message = "Occurrence of the week within the month must be between 1 and 5 or -1 for last week within the month."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,7 @@ variable "schedules" {
     interval  = number
     run_time  = string
     start_vm  = bool
+    week_days = list(string)
   }))
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "schedules" {
     interval  = number
     run_time  = string
     start_vm  = bool
-    week_days = list(string)
+    week_days = optional(list(string))
   }))
   default = []
 }

--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 1.0.4"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Change to allow the use of `Week` and `Month` frequencies by adding the option for:

`week_days`
`month_days`
`monthly_occurrence`

This uses the `optional()` function to allow it to be backwards compatible with any scripts already using it for daily schedules, but this does mean that the required Terraform version is now `>=1.3.0`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
